### PR TITLE
[WheelVariant] `variants.json` support prototype

### DIFF
--- a/src/pip/_internal/models/candidate.py
+++ b/src/pip/_internal/models/candidate.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 from pip._vendor.packaging.version import Version
 from pip._vendor.packaging.version import parse as parse_version
@@ -10,16 +11,18 @@ from pip._internal.models.link import Link
 class InstallationCandidate:
     """Represents a potential "candidate" for installation."""
 
-    __slots__ = ["name", "version", "link"]
+    __slots__ = ["name", "version", "link", "variant_hash"]
 
     name: str
     version: Version
     link: Link
+    variant_hash: Optional[str]
 
-    def __init__(self, name: str, version: str, link: Link) -> None:
+    def __init__(self, name: str, version: str, link: Link, variant_hash: Optional[str]) -> None:
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "version", parse_version(version))
         object.__setattr__(self, "link", link)
+        object.__setattr__(self, "variant_hash", variant_hash)
 
     def __str__(self) -> str:
-        return f"{self.name!r} candidate (version {self.version} at {self.link})"
+        return f"{self.name!r} candidate (version {self.version} at {self.link}, variant hash: {self.variant_hash})"

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -20,8 +20,6 @@ class TargetPython:
         "platforms",
         "py_version",
         "py_version_info",
-        "_valid_tags",
-        "_valid_tags_set",
     ]
 
     def __init__(
@@ -61,10 +59,6 @@ class TargetPython:
         self.py_version = py_version
         self.py_version_info = py_version_info
 
-        # This is used to cache the return value of get_(un)sorted_tags.
-        self._valid_tags: Optional[List[Tag]] = None
-        self._valid_tags_set: Optional[Set[Tag]] = None
-
     def format_given(self) -> str:
         """
         Format the given, non-None attributes for display.
@@ -85,37 +79,41 @@ class TargetPython:
             f"{key}={value!r}" for key, value in key_values if value is not None
         )
 
-    def get_sorted_tags(self) -> List[Tag]:
+    def get_sorted_tags(self,
+                        need_variants: bool = False,
+                        known_variants: Optional[set] = None,
+                        ) -> List[Tag]:
         """
         Return the supported PEP 425 tags to check wheel candidates against.
 
         The tags are returned in order of preference (most preferred first).
         """
-        if self._valid_tags is None:
-            # Pass versions=None if no py_version_info was given since
-            # versions=None uses special default logic.
-            py_version_info = self._given_py_version_info
-            if py_version_info is None:
-                version = None
-            else:
-                version = version_info_to_nodot(py_version_info)
+        # Pass versions=None if no py_version_info was given since
+        # versions=None uses special default logic.
+        py_version_info = self._given_py_version_info
+        if py_version_info is None:
+            version = None
+        else:
+            version = version_info_to_nodot(py_version_info)
 
-            tags = get_supported(
-                version=version,
-                platforms=self.platforms,
-                abis=self.abis,
-                impl=self.implementation,
-            )
-            self._valid_tags = tags
+        return get_supported(
+            version=version,
+            platforms=self.platforms,
+            abis=self.abis,
+            impl=self.implementation,
+            need_variants=need_variants,
+            known_variants=known_variants,
+        )
 
-        return self._valid_tags
-
-    def get_unsorted_tags(self) -> Set[Tag]:
+    def get_unsorted_tags(self,
+                          need_variants: bool = False,
+                          known_variants: Optional[set] = None,
+                          ) -> Set[Tag]:
         """Exactly the same as get_sorted_tags, but returns a set.
 
         This is important for performance.
         """
-        if self._valid_tags_set is None:
-            self._valid_tags_set = set(self.get_sorted_tags())
-
-        return self._valid_tags_set
+        return set(self.get_sorted_tags(
+            need_variants=need_variants,
+            known_variants=known_variants,
+        ))

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -81,7 +81,7 @@ class TargetPython:
 
     def get_sorted_tags(self,
                         need_variants: bool = False,
-                        known_variants: Optional[dict[str, dict[str, str]]] = None
+                        variants_json: Optional[dict] = None
                         ) -> List[Tag]:
         """
         Return the supported PEP 425 tags to check wheel candidates against.
@@ -102,12 +102,12 @@ class TargetPython:
             abis=self.abis,
             impl=self.implementation,
             need_variants=need_variants,
-            known_variants=known_variants,
+            variants_json=variants_json,
         )
 
     def get_unsorted_tags(self,
                           need_variants: bool = False,
-                          known_variants: Optional[dict[str, dict[str, str]]] = None
+                          variants_json: Optional[dict] = None
                           ) -> Set[Tag]:
         """Exactly the same as get_sorted_tags, but returns a set.
 
@@ -115,5 +115,5 @@ class TargetPython:
         """
         return set(self.get_sorted_tags(
             need_variants=need_variants,
-            known_variants=known_variants,
+            variants_json=variants_json,
         ))

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -5,6 +5,7 @@ from pip._vendor.packaging.tags import Tag
 
 from pip._internal.utils.compatibility_tags import get_supported, version_info_to_nodot
 from pip._internal.utils.misc import normalize_version_info
+from pip._internal.utils.variant import VariantJson
 
 
 class TargetPython:
@@ -81,7 +82,7 @@ class TargetPython:
 
     def get_sorted_tags(self,
                         need_variants: bool = False,
-                        variants_json: Optional[dict] = None
+                        variants_json: Optional[VariantJson] = None
                         ) -> List[Tag]:
         """
         Return the supported PEP 425 tags to check wheel candidates against.
@@ -107,7 +108,7 @@ class TargetPython:
 
     def get_unsorted_tags(self,
                           need_variants: bool = False,
-                          variants_json: Optional[dict] = None
+                          variants_json: Optional[VariantJson] = None
                           ) -> Set[Tag]:
         """Exactly the same as get_sorted_tags, but returns a set.
 

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -81,7 +81,7 @@ class TargetPython:
 
     def get_sorted_tags(self,
                         need_variants: bool = False,
-                        known_variants: Optional[set] = None,
+                        known_variants: Optional[dict[str, dict[str, str]]] = None
                         ) -> List[Tag]:
         """
         Return the supported PEP 425 tags to check wheel candidates against.
@@ -107,7 +107,7 @@ class TargetPython:
 
     def get_unsorted_tags(self,
                           need_variants: bool = False,
-                          known_variants: Optional[set] = None,
+                          known_variants: Optional[dict[str, dict[str, str]]] = None
                           ) -> Set[Tag]:
         """Exactly the same as get_sorted_tags, but returns a set.
 

--- a/src/pip/_internal/models/wheel.py
+++ b/src/pip/_internal/models/wheel.py
@@ -20,8 +20,8 @@ class Wheel:
 
     wheel_file_re = re.compile(
         r"""^(?P<namever>(?P<name>[^\s-]+?)-(?P<ver>[^\s-]*?))
-        ((-(?P<build>\d[^-]*?))?(-~(?P<variant_hash>[0-9a-f]{8})~)?
-        -(?P<pyver>[^\s-]+?)-(?P<abi>[^\s-]+?)-(?P<plat>[^\s-]+?)
+        ((-(?P<build>\d[^-]*?))?-(?P<pyver>[^\s-]+?)-(?P<abi>[^\s-]+?)-(?P<plat>[^\s-]+?)
+        (-(?P<variant_hash>[0-9a-f]{8})([+][^\s-]*)?)?
         \.whl|\.dist-info)$""",
         re.VERBOSE,
     )

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -144,6 +144,8 @@ def get_supported(
     platforms: Optional[List[str]] = None,
     impl: Optional[str] = None,
     abis: Optional[List[str]] = None,
+    need_variants: bool = False,
+    known_variants: Optional[set] = None
 ) -> List[Tag]:
     """Return a list of supported tags for each version specified in
     `versions`.
@@ -192,7 +194,12 @@ def get_supported(
         )
     )
 
-    if variants_by_priority := get_cached_variant_hashes_by_priority():
+    if need_variants:
+        if known_variants is None:
+            variants_by_priority = get_cached_variant_hashes_by_priority()
+        else:
+            raise NotImplementedError()
+
         # NOTE: There is two choices implementation wise
         # QUESTION: Which one should be the outer loop ?
         #

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -1,5 +1,6 @@
 """Generate and work with PEP 425 Compatibility Tags."""
 
+from functools import cache
 import logging
 import re
 from typing import List, Optional, Tuple
@@ -16,7 +17,7 @@ from pip._vendor.packaging.tags import (
     mac_platforms,
 )
 
-from pip._internal.utils.variant import get_cached_variant_hashes_by_priority
+from pip._internal.utils.variant import get_cached_variant_hashes_by_priority, VariantJson
 
 _apple_arch_pat = re.compile(r"(.+)_(\d+)_(\d+)_(.+)")
 
@@ -137,13 +138,14 @@ def _get_custom_interpreter(
     return f"{implementation}{version}"
 
 
+@cache
 def get_supported(
     version: Optional[str] = None,
     platforms: Optional[List[str]] = None,
     impl: Optional[str] = None,
     abis: Optional[List[str]] = None,
     need_variants: bool = False,
-    variants_json: Optional[dict] = None
+    variants_json: Optional[VariantJson] = None
 ) -> List[Tag]:
     """Return a list of supported tags for each version specified in
     `versions`.

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -2,7 +2,6 @@
 
 import logging
 import re
-from functools import cache
 from typing import List, Optional, Tuple
 
 from pip._vendor.packaging.tags import (
@@ -138,14 +137,13 @@ def _get_custom_interpreter(
     return f"{implementation}{version}"
 
 
-@cache
 def get_supported(
     version: Optional[str] = None,
     platforms: Optional[List[str]] = None,
     impl: Optional[str] = None,
     abis: Optional[List[str]] = None,
     need_variants: bool = False,
-    known_variants: Optional[set] = None
+    known_variants: Optional[dict[str, dict[str, str]]] = None
 ) -> List[Tag]:
     """Return a list of supported tags for each version specified in
     `versions`.
@@ -198,7 +196,8 @@ def get_supported(
         if known_variants is None:
             variants_by_priority = get_cached_variant_hashes_by_priority()
         else:
-            raise NotImplementedError()
+            # TODO: sorting
+            variants_by_priority = list(known_variants)
 
         # NOTE: There is two choices implementation wise
         # QUESTION: Which one should be the outer loop ?

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -143,7 +143,7 @@ def get_supported(
     impl: Optional[str] = None,
     abis: Optional[List[str]] = None,
     need_variants: bool = False,
-    known_variants: Optional[dict[str, dict[str, str]]] = None
+    variants_json: Optional[dict] = None
 ) -> List[Tag]:
     """Return a list of supported tags for each version specified in
     `versions`.
@@ -193,11 +193,7 @@ def get_supported(
     )
 
     if need_variants:
-        if known_variants is None:
-            variants_by_priority = get_cached_variant_hashes_by_priority()
-        else:
-            # TODO: sorting
-            variants_by_priority = list(known_variants)
+        variants_by_priority = get_cached_variant_hashes_by_priority(variants_json=variants_json)
 
         # NOTE: There is two choices implementation wise
         # QUESTION: Which one should be the outer loop ?

--- a/src/pip/_internal/utils/variant.py
+++ b/src/pip/_internal/utils/variant.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from functools import cache
 
 from variantlib.platform import get_variant_hashes_by_priority
 
@@ -34,8 +33,24 @@ def read_provider_priority_from_pip_config() -> dict[str, int]:
         return {}
 
 
-@cache
-def get_cached_variant_hashes_by_priority() -> list[str]:
+class VariantCache:
+    def __init__(self, func):
+        self._func = func
+        self._cache = {}
+
+    def __call__(self,
+                 variants_json: Optional[dict] = None
+                 ) -> list[str]:
+        cache_key = tuple((variants_json or {}).get("variants"))
+        if cache_key not in self._cache:
+            self._cache[cache_key] = self._func(variants_json)
+        return self._cache[cache_key]
+
+
+@VariantCache
+def get_cached_variant_hashes_by_priority(
+        variants_json: Optional[dict] = None
+        ) -> list[str]:
     variants = list(get_variant_hashes_by_priority())
     if variants:
         logger.info(f"Total Number of Compatible Variants: {len(variants):,}")  # noqa: G004

--- a/src/pip/_internal/utils/variant.py
+++ b/src/pip/_internal/utils/variant.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from functools import cache
 import logging
 
 from variantlib.platform import get_variant_hashes_by_priority
@@ -33,23 +34,14 @@ def read_provider_priority_from_pip_config() -> dict[str, int]:
         return {}
 
 
-class VariantCache:
-    def __init__(self, func):
-        self._func = func
-        self._cache = {}
-
-    def __call__(self,
-                 variants_json: Optional[dict] = None
-                 ) -> list[str]:
-        cache_key = tuple((variants_json or {}).get("variants"))
-        if cache_key not in self._cache:
-            self._cache[cache_key] = self._func(variants_json)
-        return self._cache[cache_key]
+class VariantJson(dict):
+    def __hash__(self):
+        return hash(tuple(self.get("variants")))
 
 
-@VariantCache
+@cache
 def get_cached_variant_hashes_by_priority(
-        variants_json: Optional[dict] = None
+        variants_json: Optional[VariantJson] = None
         ) -> list[str]:
     variants = list(get_variant_hashes_by_priority())
     if variants:

--- a/src/pip/_internal/utils/variant.py
+++ b/src/pip/_internal/utils/variant.py
@@ -43,7 +43,7 @@ class VariantJson(dict):
 def get_cached_variant_hashes_by_priority(
         variants_json: Optional[VariantJson] = None
         ) -> list[str]:
-    variants = list(get_variant_hashes_by_priority())
+    variants = list(get_variant_hashes_by_priority(variants_json=variants_json))
     if variants:
         logger.info(f"Total Number of Compatible Variants: {len(variants):,}")  # noqa: G004
     return variants


### PR DESCRIPTION
Quite hacky, but I think that's the simplest way of injecting it. Basically:

1. Add `need_variants` and `variants_json` argument that are passed transitively to `get_supported():
   1. If we have `variants.json`, we use the fast path to generate supported tags from specified variants.
   2. If we don't have `variants.json` and none of the wheels include a variant hash, we don't include variants in supported tags, so we don't introduce slowdown for non-variant packages.
   3. IF we don't have `variants.json` and at least one includes a variant hash, we use the previous logic of generating all variants.
2. The index lookup logic considers `variants.json` file first, so that we have it processed before processing the first wheel. Since the code apparently processes the index multiple times, I've added caching to avoid refetching it.
3. The JSON from `variants.json` is wrapped into thin `VariantJson` class that adds a `__hash__()` method, so that it can trivially work with `@cache`.

Requires wheelnext/variantlib#2