### PR TITLE
Index priority without index groups

### DIFF
--- a/src/pip/_internal/cli/cmdoptions.py
+++ b/src/pip/_internal/cli/cmdoptions.py
@@ -363,6 +363,17 @@ def extra_index_url() -> Option:
         "--index-url.",
     )
 
+def index_groups() -> Option:
+    return Option(
+        "--index-groups",
+        dest="index_groups",
+        metavar="URL",
+        action="append",
+        default=[],
+        help="Index Groups of package indexes to use in addition to "
+        "--index-url. Should follow the similar rules as but applies for groups."
+        "--index-url.",
+    )
 
 no_index: Callable[..., Option] = partial(
     Option,
@@ -1069,6 +1080,7 @@ index_group: Dict[str, Any] = {
     "options": [
         index_url,
         extra_index_url,
+        index_groups,
         no_index,
         find_links,
     ],

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -32,7 +32,7 @@ from pip._vendor import requests
 from pip._vendor.requests import Response
 from pip._vendor.requests.exceptions import RetryError, SSLError
 
-from pip._internal.exceptions import NetworkConnectionError
+from pip._internal.exceptions import NetworkConnectionError, CommandError
 from pip._internal.models.link import Link
 from pip._internal.models.search_scope import SearchScope
 from pip._internal.network.session import PipSession
@@ -416,6 +416,12 @@ class LinkCollector:
             when constructing the SearchScope object.
         """
         index_urls = [options.index_url] + options.extra_index_urls
+        index_priority = False
+        if (options.index_groups is not None and len(options.index_groups) > 0):
+            print(options.index_groups[0])
+            index_urls = options.index_groups[0].split(",")
+            index_priority = True
+            
         if options.no_index and not suppress_no_index:
             logger.debug(
                 "Ignoring indexes: %s",
@@ -430,6 +436,7 @@ class LinkCollector:
             find_links=find_links,
             index_urls=index_urls,
             no_index=options.no_index,
+            index_priority=index_priority,
         )
         link_collector = LinkCollector(
             session=session,

--- a/src/pip/_internal/index/collector.py
+++ b/src/pip/_internal/index/collector.py
@@ -418,7 +418,6 @@ class LinkCollector:
         index_urls = [options.index_url] + options.extra_index_urls
         index_priority = False
         if (options.index_groups is not None and len(options.index_groups) > 0):
-            print(options.index_groups[0])
             index_urls = options.index_groups[0].split(",")
             index_priority = True
             

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -581,14 +581,11 @@ class CandidateEvaluator:
                     found_candidate = True
                     break
 
-
         # fall back on default behavior
         if not found_candidate:
             applicable_candidates = self.get_applicable_candidates(candidates)
             best_candidate = self.sort_best_candidate(applicable_candidates)
 
-        logger.debug(f"compute_best_candidate: {best_candidate}")
-        logger.debug(f"out of: {candidates}")
         return BestCandidateResult(
             candidates,
             applicable_candidates=applicable_candidates,
@@ -954,7 +951,6 @@ class PackageFinder:
             hashes=hashes,
         )
         best_candidate = best_candidate_result.best_candidate
-        logger.debug(f"***best_candidate: {best_candidate}")
 
         installed_version: Optional[_BaseVersion] = None
         if req.satisfied_by is not None:

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -125,6 +125,8 @@ class LinkEvaluator:
         target_python: TargetPython,
         allow_yanked: bool,
         ignore_requires_python: Optional[bool] = None,
+        index_priority: bool = False,
+        index_urls: Optional[List[str]] = None,
     ) -> None:
         """
         :param project_name: The user supplied package name.
@@ -151,6 +153,8 @@ class LinkEvaluator:
         self._ignore_requires_python = ignore_requires_python
         self._formats = formats
         self._target_python = target_python
+        self._index_priority = index_priority
+        self._index_urls = index_urls
 
         self.project_name = project_name
 
@@ -375,6 +379,8 @@ class CandidateEvaluator:
         allow_all_prereleases: bool = False,
         specifier: Optional[specifiers.BaseSpecifier] = None,
         hashes: Optional[Hashes] = None,
+        index_priority: bool = False,
+        index_urls: Optional[List[str]] = None,
     ) -> "CandidateEvaluator":
         """Create a CandidateEvaluator object.
 
@@ -400,6 +406,8 @@ class CandidateEvaluator:
             prefer_binary=prefer_binary,
             allow_all_prereleases=allow_all_prereleases,
             hashes=hashes,
+            index_priority=index_priority,
+            index_urls=index_urls,
         )
 
     def __init__(
@@ -410,6 +418,8 @@ class CandidateEvaluator:
         prefer_binary: bool = False,
         allow_all_prereleases: bool = False,
         hashes: Optional[Hashes] = None,
+        index_priority: bool = False,
+        index_urls: Optional[List[str]] = None,
     ) -> None:
         """
         :param supported_tags: The PEP 425 tags supported by the target
@@ -421,6 +431,8 @@ class CandidateEvaluator:
         self._project_name = project_name
         self._specifier = specifier
         self._supported_tags = supported_tags
+        self._index_priority = index_priority
+        self._index_urls = index_urls
         # Since the index of the tag in the _supported_tags list is used
         # as a priority, precompute a map from tag to index/priority to be
         # used in wheel.find_most_preferred_tag.
@@ -552,10 +564,31 @@ class CandidateEvaluator:
         """
         Compute and return a `BestCandidateResult` instance.
         """
-        applicable_candidates = self.get_applicable_candidates(candidates)
 
-        best_candidate = self.sort_best_candidate(applicable_candidates)
+        # Apply priority filtering to the list of candidates
+        found_candidate = False
+        if(self._index_priority and self._index_urls is not None):
+            for index_url in self._index_urls:
+                index_priority_candidates = list()
+                for candidate in candidates:
+                    # filter out candidates by current priority index
+                    if candidate.link.comes_from.startswith(index_url):
+                        index_priority_candidates.append(candidate)
 
+                if(len(index_priority_candidates) > 0):
+                    applicable_candidates = self.get_applicable_candidates(index_priority_candidates)
+                    best_candidate = self.sort_best_candidate(applicable_candidates)
+                    found_candidate = True
+                    break
+
+
+        # fall back on default behavior
+        if not found_candidate:
+            applicable_candidates = self.get_applicable_candidates(candidates)
+            best_candidate = self.sort_best_candidate(applicable_candidates)
+
+        logger.debug(f"compute_best_candidate: {best_candidate}")
+        logger.debug(f"out of: {candidates}")
         return BestCandidateResult(
             candidates,
             applicable_candidates=applicable_candidates,
@@ -662,6 +695,10 @@ class PackageFinder:
         return self.search_scope.index_urls
 
     @property
+    def index_priority(self) -> bool:
+        return self.search_scope.index_priority
+
+    @property
     def proxy(self) -> Optional[str]:
         return self._link_collector.session.pip_proxy
 
@@ -717,6 +754,8 @@ class PackageFinder:
             target_python=self._target_python,
             allow_yanked=self._allow_yanked,
             ignore_requires_python=self._ignore_requires_python,
+            index_priority=self.index_priority,
+            index_urls=self.index_urls,
         )
 
     def _sort_links(self, links: Iterable[Link]) -> List[Link]:
@@ -872,6 +911,8 @@ class PackageFinder:
             allow_all_prereleases=candidate_prefs.allow_all_prereleases,
             specifier=specifier,
             hashes=hashes,
+            index_priority=self.index_priority,
+            index_urls=self.index_urls,
         )
 
     @functools.lru_cache(maxsize=None)
@@ -913,6 +954,7 @@ class PackageFinder:
             hashes=hashes,
         )
         best_candidate = best_candidate_result.best_candidate
+        logger.debug(f"***best_candidate: {best_candidate}")
 
         installed_version: Optional[_BaseVersion] = None
         if req.satisfied_by is not None:

--- a/src/pip/_internal/models/search_scope.py
+++ b/src/pip/_internal/models/search_scope.py
@@ -21,11 +21,12 @@ class SearchScope:
     Encapsulates the locations that pip is configured to search.
     """
 
-    __slots__ = ["find_links", "index_urls", "no_index"]
+    __slots__ = ["find_links", "index_urls", "no_index", "index_priority"]
 
     find_links: List[str]
     index_urls: List[str]
     no_index: bool
+    index_priority: bool
 
     @classmethod
     def create(
@@ -33,6 +34,7 @@ class SearchScope:
         find_links: List[str],
         index_urls: List[str],
         no_index: bool,
+        index_priority: bool = False,
     ) -> "SearchScope":
         """
         Create a SearchScope object after normalizing the `find_links`.
@@ -67,6 +69,7 @@ class SearchScope:
             find_links=built_find_links,
             index_urls=index_urls,
             no_index=no_index,
+            index_priority=index_priority,
         )
 
     def get_formatted_locations(self) -> str:

--- a/src/pip/_internal/req/req_file.py
+++ b/src/pip/_internal/req/req_file.py
@@ -52,6 +52,7 @@ ENV_VAR_RE = re.compile(r"(?P<var>\$\{(?P<name>[A-Z0-9_]+)\})")
 SUPPORTED_OPTIONS: List[Callable[..., optparse.Option]] = [
     cmdoptions.index_url,
     cmdoptions.extra_index_url,
+    cmdoptions.index_groups,
     cmdoptions.no_index,
     cmdoptions.constraints,
     cmdoptions.requirements,


### PR DESCRIPTION
Working with @msarahan on Index Priority. https://github.com/pypa/pip/pull/13210

Hack way of prioritizing indexes

Test 1:
`` pip install torch --index-groups https://download.pytorch.org/whl/test/cpu,https://download.pytorch.org/whl/nightly/cpu --force-reinstall --dry-run``

Output:
```
 pip install torch --index-groups https://download.pytorch.org/whl/test/cpu,https://download.pytorch.org/whl/nightly/cpu --force-reinstall --dry-run
https://download.pytorch.org/whl/test/cpu,https://download.pytorch.org/whl/nightly/cpu
Looking in indexes: https://download.pytorch.org/whl/test/cpu, https://download.pytorch.org/whl/nightly/cpu
Collecting torch
  Using cached https://download.pytorch.org/whl/test/cpu/torch-2.7.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (27 kB)
Collecting filelock (from torch)
  Using cached https://download.pytorch.org/whl/test/filelock-3.13.1-py3-none-any.whl (11 kB)
Collecting typing-extensions>=4.10.0 (from torch)
  Using cached https://download.pytorch.org/whl/test/typing_extensions-4.12.2-py3-none-any.whl (37 kB)
Collecting sympy>=1.13.3 (from torch)
  Using cached https://download.pytorch.org/whl/test/sympy-1.13.3-py3-none-any.whl.metadata (12 kB)
Collecting networkx (from torch)
  Using cached https://download.pytorch.org/whl/test/networkx-3.3-py3-none-any.whl (1.7 MB)
Collecting jinja2 (from torch)
  Using cached https://download.pytorch.org/whl/test/Jinja2-3.1.4-py3-none-any.whl (133 kB)
Collecting fsspec (from torch)
  Using cached https://download.pytorch.org/whl/test/fsspec-2024.6.1-py3-none-any.whl (177 kB)
Collecting mpmath<1.4,>=1.1.0 (from sympy>=1.13.3->torch)
  Using cached https://download.pytorch.org/whl/test/mpmath-1.3.0-py3-none-any.whl (536 kB)
Collecting MarkupSafe>=2.0 (from jinja2->torch)
  Using cached https://download.pytorch.org/whl/test/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (28 kB)
Using cached https://download.pytorch.org/whl/test/cpu/torch-2.7.0%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl (176.0 MB)
Using cached https://download.pytorch.org/whl/test/sympy-1.13.3-py3-none-any.whl (6.2 MB)
Would install Jinja2-3.1.4 MarkupSafe-2.1.5 filelock-3.13.1 fsspec-2024.6.1 mpmath-1.3.0 networkx-3.3 sympy-1.13.3 torch-2.7.0+cpu typing_extensions-4.12.2
```

Test 2:
`` pip install torch --index-groups https://download.pytorch.org/whl/nightly/cpu,https://download.pytorch.org/whl/test/cpu --force-reinstall --dry-run``

Output:
```
pip install torch --index-groups https://download.pytorch.org/whl/nightly/cpu,https://download.pytorch.org/whl/test/cpu --force-reinstall --dry-run
https://download.pytorch.org/whl/nightly/cpu,https://download.pytorch.org/whl/test/cpu
Looking in indexes: https://download.pytorch.org/whl/nightly/cpu, https://download.pytorch.org/whl/test/cpu
Collecting torch
  Using cached https://download.pytorch.org/whl/nightly/cpu/torch-2.8.0.dev20250320%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl.metadata (27 kB)
Collecting filelock (from torch)
  Using cached https://download.pytorch.org/whl/nightly/filelock-3.16.1-py3-none-any.whl (16 kB)
Collecting typing-extensions>=4.10.0 (from torch)
  Using cached https://download.pytorch.org/whl/nightly/typing_extensions-4.12.2-py3-none-any.whl (37 kB)
Collecting sympy>=1.13.3 (from torch)
  Using cached https://download.pytorch.org/whl/nightly/sympy-1.13.3-py3-none-any.whl (6.2 MB)
Collecting networkx (from torch)
  Using cached https://download.pytorch.org/whl/nightly/networkx-3.4.2-py3-none-any.whl (1.7 MB)
Collecting jinja2 (from torch)
  Using cached https://download.pytorch.org/whl/nightly/jinja2-3.1.4-py3-none-any.whl (133 kB)
Collecting fsspec (from torch)
  Using cached https://download.pytorch.org/whl/nightly/fsspec-2024.10.0-py3-none-any.whl (179 kB)
Collecting mpmath<1.4,>=1.1.0 (from sympy>=1.13.3->torch)
  Using cached https://download.pytorch.org/whl/nightly/mpmath-1.3.0-py3-none-any.whl (536 kB)
Collecting MarkupSafe>=2.0 (from jinja2->torch)
  Using cached https://download.pytorch.org/whl/nightly/MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (28 kB)
Using cached https://download.pytorch.org/whl/nightly/cpu/torch-2.8.0.dev20250320%2Bcpu-cp311-cp311-manylinux_2_28_x86_64.whl (177.6 MB)
Would install Jinja2-3.1.4 MarkupSafe-2.1.5 filelock-3.16.1 fsspec-2024.10.0 mpmath-1.3.0 networkx-3.4.2 sympy-1.13.3 torch-2.8.0.dev20250320+cpu typing_extensions-4.12.2
```