### PR TITLE
Remove support for combinatorial approach to variants

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -205,7 +205,6 @@ class LinkEvaluator:
 
                 variant_hash = wheel.variant_hash
                 supported_tags = self._target_python.get_unsorted_tags(
-                    need_variants=variant_hash is not None,
                     variants_json=self.variants_json)
                 if not wheel.supported(supported_tags):
                     # Include the wheel's tags in the reason string to
@@ -384,7 +383,6 @@ class CandidateEvaluator:
         allow_all_prereleases: bool = False,
         specifier: Optional[specifiers.BaseSpecifier] = None,
         hashes: Optional[Hashes] = None,
-        need_variants: bool = False,
         variants_json: Optional[VariantJson] = None
     ) -> "CandidateEvaluator":
         """Create a CandidateEvaluator object.
@@ -403,7 +401,6 @@ class CandidateEvaluator:
             specifier = specifiers.SpecifierSet()
 
         supported_tags = target_python.get_sorted_tags(
-            need_variants=need_variants,
             variants_json=variants_json,
         )
 
@@ -888,7 +885,6 @@ class PackageFinder:
         project_name: str,
         specifier: Optional[specifiers.BaseSpecifier] = None,
         hashes: Optional[Hashes] = None,
-        need_variants: bool = False,
         variants_json: Optional[VariantJson] = None
     ) -> CandidateEvaluator:
         """Create a CandidateEvaluator object to use."""
@@ -900,7 +896,6 @@ class PackageFinder:
             allow_all_prereleases=candidate_prefs.allow_all_prereleases,
             specifier=specifier,
             hashes=hashes,
-            need_variants=need_variants,
             variants_json=variants_json,
         )
 
@@ -924,8 +919,6 @@ class PackageFinder:
             project_name=project_name,
             specifier=specifier,
             hashes=hashes,
-            need_variants=any(x.variant_hash is not None
-                              for x in candidates),
             variants_json=variants_json,
         )
         return candidate_evaluator.compute_best_candidate(candidates)

--- a/src/pip/_internal/models/target_python.py
+++ b/src/pip/_internal/models/target_python.py
@@ -81,7 +81,6 @@ class TargetPython:
         )
 
     def get_sorted_tags(self,
-                        need_variants: bool = False,
                         variants_json: Optional[VariantJson] = None
                         ) -> List[Tag]:
         """
@@ -102,12 +101,10 @@ class TargetPython:
             platforms=self.platforms,
             abis=self.abis,
             impl=self.implementation,
-            need_variants=need_variants,
             variants_json=variants_json,
         )
 
     def get_unsorted_tags(self,
-                          need_variants: bool = False,
                           variants_json: Optional[VariantJson] = None
                           ) -> Set[Tag]:
         """Exactly the same as get_sorted_tags, but returns a set.
@@ -115,6 +112,5 @@ class TargetPython:
         This is important for performance.
         """
         return set(self.get_sorted_tags(
-            need_variants=need_variants,
             variants_json=variants_json,
         ))

--- a/src/pip/_internal/utils/compatibility_tags.py
+++ b/src/pip/_internal/utils/compatibility_tags.py
@@ -144,7 +144,6 @@ def get_supported(
     platforms: Optional[List[str]] = None,
     impl: Optional[str] = None,
     abis: Optional[List[str]] = None,
-    need_variants: bool = False,
     variants_json: Optional[VariantJson] = None
 ) -> List[Tag]:
     """Return a list of supported tags for each version specified in
@@ -194,7 +193,7 @@ def get_supported(
         )
     )
 
-    if need_variants:
+    if variants_json is not None:
         variants_by_priority = get_cached_variant_hashes_by_priority(variants_json=variants_json)
 
         # NOTE: There is two choices implementation wise


### PR DESCRIPTION
Remove the support for combinatorial approach to variants, leaving only `variants.json` support.  Remove the redundant `need_variants` parameter, as the use of variants is now governed by the presence of `variants_json`.