### PR TITLE
Make `pip wheel` work again

### DIFF
--- a/src/pip/_internal/cli/req_command.py
+++ b/src/pip/_internal/cli/req_command.py
@@ -337,7 +337,7 @@ class RequirementCommand(IndexGroupCommand):
             allow_all_prereleases=options.pre,
             prefer_binary=options.prefer_binary,
             ignore_requires_python=ignore_requires_python,
-            use_variants=options.use_variants,
+            use_variants=options.use_variants if hasattr(options, "use_variants") else False,
         )
 
         return PackageFinder.create(


### PR DESCRIPTION
Running `pip wheel -v --no-deps` to build a wheel fails with the error
```
ERROR: Exception:
Traceback (most recent call last):
  File "/home/phcho/miniforge3/envs/wheelnext/lib/python3.13/site-packages/pip/_internal/cli/base_command.py", line 106, in _run_wrapper
    status = _inner_run()
  File "/home/phcho/miniforge3/envs/wheelnext/lib/python3.13/site-packages/pip/_internal/cli/base_command.py", line 97, in _inner_run
    return self.run(options, args)
           ~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/phcho/miniforge3/envs/wheelnext/lib/python3.13/site-packages/pip/_internal/cli/req_command.py", line 68, in wrapper
    return func(self, options, args)
  File "/home/phcho/miniforge3/envs/wheelnext/lib/python3.13/site-packages/pip/_internal/commands/wheel.py", line 107, in run
    finder = self._build_package_finder(options, session)
  File "/home/phcho/miniforge3/envs/wheelnext/lib/python3.13/site-packages/pip/_internal/cli/req_command.py", line 341, in _build_package_finder
    use_variants=options.use_variants,
                 ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Values' object has no attribute 'use_variants'
```

The error is probably because `pip wheel` doesn't yet provide the CLI parameter `use_variants`.

Fix. Set `use_variants=False` if the CLI parameter is not given.