### PR TITLE
Support older Python and find-links

### DIFF
--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -896,9 +896,6 @@ class PackageFinder:
         page_links = list(parse_links(index_response))
 
         with indent_log():
-            # This is how evaluate_links gets called in a way that gets the
-            # variants.json file processed for URLs. I need to insert the same
-            # thing for find-links
             package_links = self.evaluate_links(
                 link_evaluator,
                 links=page_links,
@@ -937,7 +934,7 @@ class PackageFinder:
         # Since candidates_from_page does not get used to process file sources
         # from find-links, manually inject evaluate_links calls here.
         _links = [
-            Link(path_to_url(fl.variants_json)) 
+            Link(path_to_url(fl.variants_json))
             for fl in collected_sources.find_links
             if fl.variants_json is not None
         ]

--- a/src/pip/_internal/index/package_finder.py
+++ b/src/pip/_internal/index/package_finder.py
@@ -37,6 +37,7 @@ from pip._internal.utils.logging import indent_log
 from pip._internal.utils.misc import build_netloc
 from pip._internal.utils.packaging import check_requires_python
 from pip._internal.utils.unpacking import SUPPORTED_EXTENSIONS
+from pip._internal.utils.urls import path_to_url
 from pip._internal.utils.variant import (
     VariantJson,
     get_cached_variant_hashes_by_priority,
@@ -895,6 +896,9 @@ class PackageFinder:
         page_links = list(parse_links(index_response))
 
         with indent_log():
+            # This is how evaluate_links gets called in a way that gets the
+            # variants.json file processed for URLs. I need to insert the same
+            # thing for find-links
             package_links = self.evaluate_links(
                 link_evaluator,
                 links=page_links,
@@ -930,6 +934,14 @@ class PackageFinder:
         )
         page_candidates = list(page_candidates_it)
 
+        # Since candidates_from_page does not get used to process file sources
+        # from find-links, manually inject evaluate_links calls here.
+        _links = [
+            Link(path_to_url(fl.variants_json)) 
+            for fl in collected_sources.find_links
+            if fl.variants_json is not None
+        ]
+        self.evaluate_links(link_evaluator, _links)
         file_links_it = itertools.chain.from_iterable(
             source.file_links()
             for sources in collected_sources

--- a/src/pip/_internal/index/sources.py
+++ b/src/pip/_internal/index/sources.py
@@ -51,6 +51,7 @@ class _FlatDirectoryToUrls:
         self._path = path
         self._page_candidates: List[str] = []
         self._project_name_to_urls: Dict[str, List[str]] = defaultdict(list)
+        self.variants_json = None
         self._scanned_directory = False
 
     def _scan_directory(self) -> None:
@@ -71,6 +72,8 @@ class _FlatDirectoryToUrls:
                 try:
                     project_filename = parse_sdist_filename(entry.name)[0]
                 except InvalidSdistFilename:
+                    if entry.name.endswith("-variants.json"):
+                        self.variants_json = entry.path
                     continue
 
             self._project_name_to_urls[project_filename].append(url)
@@ -129,6 +132,10 @@ class _FlatDirectorySource(LinkSource):
     def file_links(self) -> FoundLinks:
         for url in self._path_to_urls.project_name_to_urls[self._project_name]:
             yield Link(url)
+
+    @property
+    def variants_json(self):
+        return self._path_to_urls.variants_json
 
 
 class _LocalFileSource(LinkSource):

--- a/src/pip/_internal/utils/variant.py
+++ b/src/pip/_internal/utils/variant.py
@@ -49,7 +49,7 @@ class VariantJson:
 def get_variants_json_filename(wheel: Wheel) -> str:
     # these are normalized, but with .replace("_", "-")
     return (
-        f"{wheel.name.replace("-", "_")}-{wheel.version.replace("-", "_")}-"
+        f"{wheel.name.replace('-', '_')}-{wheel.version.replace('-', '_')}-"
         "variants.json"
     )
 

--- a/src/pip/_vendor/packaging/utils.py
+++ b/src/pip/_vendor/packaging/utils.py
@@ -101,7 +101,7 @@ def parse_wheel_filename(
 
     filename = filename[:-4]
     dashes = filename.count("-")
-    if dashes not in (4, 5):
+    if dashes not in (4, 5, 6):
         raise InvalidWheelFilename(
             f"Invalid wheel filename (wrong number of parts): {filename!r}"
         )
@@ -120,14 +120,22 @@ def parse_wheel_filename(
             f"Invalid wheel filename (invalid version): {filename!r}"
         ) from e
 
-    if dashes == 5:
+    if dashes in (5, 6):
         build_part = parts[2]
         build_match = _build_tag_regex.match(build_part)
         if build_match is None:
-            raise InvalidWheelFilename(
-                f"Invalid build number: {build_part} in {filename!r}"
-            )
-        build = cast(BuildTag, (int(build_match.group(1)), build_match.group(2)))
+            # When there are 5 dashes, not matching the build number could be OK because
+            # we could have a variant tag.
+            variant_hash_pattern = r'[a-zA-Z0-9]{8}'
+            possible_variant_hash = parts[-1].split("-")[-1]
+            if dashes == 6 or (dashes == 5 and not re.match(variant_hash_pattern, possible_variant_hash)):
+                raise InvalidWheelFilename(
+                    f"Invalid build number: {build_part} in {filename!r}"
+                )
+            else:
+                build = ()
+        else:
+            build = cast(BuildTag, (int(build_match.group(1)), build_match.group(2)))
     else:
         build = ()
     tags = parse_tag(parts[-1])


### PR DESCRIPTION
<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
This PR allows running on versions of Python before 3.12 because the code is currently using some f-string syntax that requires PEP 701 (specifically, using double quotes inside an f-string that is already delimited by double quotes). Beyond that, this PR supports using pip's `--find-links` argument to discover local directories containing variant builds.