### PR TITLE
Apply default extras when resolving an already-installed candidate

### DIFF
--- a/src/pip/__init__.py
+++ b/src/pip/__init__.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-__version__ = "25.0.dev0"
+__version__ = "25.0.dev0+pep-771"
 
 
 def main(args: Optional[List[str]] = None) -> int:

--- a/src/pip/_internal/metadata/_json.py
+++ b/src/pip/_internal/metadata/_json.py
@@ -30,6 +30,7 @@ METADATA_FIELDS = [
     ("Requires-Python", False),
     ("Requires-External", True),
     ("Project-URL", True),
+    ("Default-Extra", True),
     ("Provides-Extra", True),
     ("Provides-Dist", True),
     ("Obsoletes-Dist", True),

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -442,12 +442,27 @@ class BaseDistribution(Protocol):
 
         For modern .dist-info distributions, this is the collection of
         "Requires-Dist:" entries in distribution metadata.
+
+        In case, no "Extra" is specified, will use "Default-Extra" as specified
+        per PEP 771.
         """
         raise NotImplementedError()
 
     def iter_raw_dependencies(self) -> Iterable[str]:
         """Raw Requires-Dist metadata."""
         return self.metadata.get_all("Requires-Dist", [])
+
+    def iter_default_extras(self) -> Iterable[NormalizedName]:
+        """Extras provided by this distribution.
+
+        For modern .dist-info distributions, this is the collection of
+        "Default-Extra:" entries in distribution metadata.
+
+        The return value of this function is expected to be normalised names,
+        per PEP 771, with the returned value being handled appropriately by
+        `iter_dependencies`.
+        """
+        raise NotImplementedError()
 
     def iter_provided_extras(self) -> Iterable[NormalizedName]:
         """Extras provided by this distribution.

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -213,6 +213,12 @@ class Distribution(BaseDistribution):
             for extra in self.metadata.get_all("Provides-Extra", [])
         ]
 
+    def iter_default_extras(self) -> Iterable[NormalizedName]:
+        return [
+            canonicalize_name(extra)
+            for extra in self.metadata.get_all("Default-Extra", [])
+        ]
+
     def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
         contexts: Sequence[Dict[str, str]] = [{"extra": e} for e in extras]
         for req_string in self.metadata.get_all("Requires-Dist", []):

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -207,19 +207,22 @@ class Distribution(BaseDistribution):
         # until upstream can improve the protocol. (python/cpython#94952)
         return cast(email.message.Message, self._dist.metadata)
 
-    def iter_provided_extras(self) -> Iterable[NormalizedName]:
-        return [
-            canonicalize_name(extra)
-            for extra in self.metadata.get_all("Provides-Extra", [])
-        ]
-
     def iter_default_extras(self) -> Iterable[NormalizedName]:
         return [
             canonicalize_name(extra)
             for extra in self.metadata.get_all("Default-Extra", [])
         ]
 
+    def iter_provided_extras(self) -> Iterable[NormalizedName]:
+        return [
+            canonicalize_name(extra)
+            for extra in self.metadata.get_all("Provides-Extra", [])
+        ]
+
     def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
+        if not extras:
+            extras = list(self.iter_default_extras())
+
         contexts: Sequence[Dict[str, str]] = [{"extra": e} for e in extras]
         for req_string in self.metadata.get_all("Requires-Dist", []):
             # strip() because email.message.Message.get_all() may return a leading \n

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -239,12 +239,18 @@ class Distribution(BaseDistribution):
         return feed_parser.close()
 
     def iter_dependencies(self, extras: Collection[str] = ()) -> Iterable[Requirement]:
+        extras = extras or self._dist.default_extras_require
+
         if extras:
             relevant_extras = set(self._extra_mapping) & set(
                 map(canonicalize_name, extras)
             )
             extras = [self._extra_mapping[extra] for extra in relevant_extras]
+
         return self._dist.requires(extras)
+
+    def iter_default_extras(self) -> Iterable[NormalizedName]:
+        return self._dist.default_extras_require or []
 
     def iter_provided_extras(self) -> Iterable[NormalizedName]:
         return self._extra_mapping.keys()

--- a/src/pip/_internal/operations/prepare.py
+++ b/src/pip/_internal/operations/prepare.py
@@ -646,6 +646,12 @@ class RequirementPreparer:
             self.build_isolation,
             self.check_build_deps,
         )
+
+        # Setting up the default-extra if necessary
+        default_extras = frozenset(dist.metadata.get_all("Default-Extra", []))
+        req.extras = req.extras or default_extras
+        req.req.extras = req.extras or default_extras
+
         return dist
 
     def save_linked_requirement(self, req: InstallRequirement) -> None:

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -31,10 +31,13 @@ from pip._internal.utils.packaging import get_requirement
 from pip._internal.utils.urls import path_to_url
 from pip._internal.vcs import is_url, vcs
 
+EXPLICIT_EMPTY_EXTRAS = 'explicit-no-default-extras'
+
 __all__ = [
     "install_req_from_editable",
     "install_req_from_line",
     "parse_editable",
+    "EXPLICIT_EMPTY_EXTRAS"
 ]
 
 logger = logging.getLogger(__name__)
@@ -48,7 +51,11 @@ def _strip_extras(path: str) -> Tuple[str, Optional[str]]:
         path_no_extras = m.group(1)
         extras = m.group(2)
     else:
-        path_no_extras = path
+        if '[]' in path:
+            extras = f'[{EXPLICIT_EMPTY_EXTRAS}]'
+            path_no_extras = path.replace('[]', '')
+        else:
+            path_no_extras = path
 
     return path_no_extras, extras
 

--- a/src/pip/_internal/resolution/legacy/resolver.py
+++ b/src/pip/_internal/resolution/legacy/resolver.py
@@ -38,6 +38,7 @@ from pip._internal.req.req_install import (
     InstallRequirement,
     check_invalid_constraint_type,
 )
+from pip._internal.req.constructors import EXPLICIT_EMPTY_EXTRAS
 from pip._internal.req.req_set import RequirementSet
 from pip._internal.resolution.base import BaseResolver, InstallRequirementProvider
 from pip._internal.utils import compatibility_tags
@@ -552,12 +553,13 @@ class Resolver(BaseResolver):
                     set(req_to_install.extras) - set(dist.iter_provided_extras())
                 )
                 for missing in missing_requested:
-                    logger.warning(
-                        "%s %s does not provide the extra '%s'",
-                        dist.raw_name,
-                        dist.version,
-                        missing,
-                    )
+                    if missing != EXPLICIT_EMPTY_EXTRAS:
+                        logger.warning(
+                            "%s %s does not provide the extra '%s'",
+                            dist.raw_name,
+                            dist.version,
+                            missing,
+                        )
 
                 available_requested = sorted(
                     set(dist.iter_provided_extras()) & set(req_to_install.extras)

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -21,6 +21,7 @@ from pip._internal.req.constructors import (
     install_req_from_line,
 )
 from pip._internal.req.req_install import InstallRequirement
+from pip._internal.req.constructors import EXPLICIT_EMPTY_EXTRAS
 from pip._internal.utils.direct_url_helpers import direct_url_from_link
 from pip._internal.utils.misc import normalize_version_info
 
@@ -515,12 +516,13 @@ class ExtrasCandidate(Candidate):
         valid_extras = self.extras.intersection(self.base.dist.iter_provided_extras())
         invalid_extras = self.extras.difference(self.base.dist.iter_provided_extras())
         for extra in sorted(invalid_extras):
-            logger.warning(
-                "%s %s does not provide the extra '%s'",
-                self.base.name,
-                self.version,
-                extra,
-            )
+            if extra != EXPLICIT_EMPTY_EXTRAS:
+                logger.warning(
+                    "%s %s does not provide the extra '%s'",
+                    self.base.name,
+                    self.version,
+                    extra,
+                )
 
         for r in self.base.dist.iter_dependencies(valid_extras):
             yield from factory.make_requirements_from_spec(

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -310,6 +310,8 @@ class LinkCandidate(_InstallRequirementBackedCandidate):
             version=version,
         )
 
+        template.extras = ireq.extras
+
     def _prepare_distribution(self) -> BaseDistribution:
         preparer = self._factory.preparer
         return preparer.prepare_linked_requirement(self._ireq, parallel_builds=True)

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -504,6 +504,9 @@ class Factory:
                 name=canonicalize_name(ireq.name) if ireq.name else None,
                 version=None,
             )
+
+            extras = ireq.extras or list(cand.dist.iter_default_extras())
+
             if cand is None:
                 # There's no way we can satisfy a URL requirement if the underlying
                 # candidate fails to build. An unnamed URL must be user-supplied, so
@@ -517,10 +520,10 @@ class Factory:
             else:
                 # require the base from the link
                 yield self.make_requirement_from_candidate(cand)
-                if ireq.extras:
+                if extras:
                     # require the extras on top of the base candidate
                     yield self.make_requirement_from_candidate(
-                        self._make_extras_candidate(cand, frozenset(ireq.extras))
+                        self._make_extras_candidate(cand, frozenset(extras))
                     )
 
     def collect_root_requirements(

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -483,7 +483,7 @@ class Factory:
                 (or link) and one with the extra. This allows centralized constraint
                 handling for the base, resulting in fewer candidate rejections.
         """
-        if ireq.comes_from is not None:
+        if ireq.comes_from is not None and hasattr(ireq.comes_from, "extra"):
             requested_extras = requested_extras or ireq.comes_from.extras
 
         if not ireq.match_markers(requested_extras):

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -187,6 +187,7 @@ class Factory:
         base: Optional[BaseCandidate] = self._make_base_candidate_from_link(
             link, template, name, version
         )
+        extras = extras if extras else template.extras
         if not extras or base is None:
             return base
         return self._make_extras_candidate(base, extras, comes_from=template)
@@ -482,6 +483,9 @@ class Factory:
                 (or link) and one with the extra. This allows centralized constraint
                 handling for the base, resulting in fewer candidate rejections.
         """
+        if ireq.comes_from is not None:
+            requested_extras = requested_extras or ireq.comes_from.extras
+
         if not ireq.match_markers(requested_extras):
             logger.info(
                 "Ignoring %s: markers '%s' don't match your environment",

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -172,6 +172,15 @@ class Factory:
         except KeyError:
             base = AlreadyInstalledCandidate(dist, template, factory=self)
             self._installed_candidate_cache[dist.canonical_name] = base
+        if not extras and not template.extras:
+            default_extras = frozenset(
+                canonicalize_name(e) for e in dist.iter_default_extras()
+            )
+            if default_extras:
+                template.extras = default_extras
+                if template.req is not None:
+                    template.req.extras = default_extras
+                extras = default_extras
         if not extras:
             return base
         return self._make_extras_candidate(base, extras, comes_from=template)

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from pip._vendor.packaging.specifiers import SpecifierSet
 from pip._vendor.packaging.utils import NormalizedName, canonicalize_name
 
-from pip._internal.req.constructors import install_req_drop_extras
+from pip._internal.req.constructors import install_req_drop_extras, EXPLICIT_EMPTY_EXTRAS
 from pip._internal.req.req_install import InstallRequirement
 
 from .base import Candidate, CandidateLookup, Requirement, format_name
@@ -128,6 +128,8 @@ class SpecifierWithoutExtrasRequirement(SpecifierRequirement):
     def __init__(self, ireq: InstallRequirement) -> None:
         assert ireq.link is None, "This is a link, not a specifier"
         self._ireq = install_req_drop_extras(ireq)
+        if ireq.extras:
+            self._ireq.extras = {EXPLICIT_EMPTY_EXTRAS}
         self._equal_cache: Optional[str] = None
         self._hash: Optional[int] = None
         self._extras = frozenset(canonicalize_name(e) for e in self._ireq.extras)

--- a/src/pip/_vendor/packaging/metadata.py
+++ b/src/pip/_vendor/packaging/metadata.py
@@ -132,6 +132,9 @@ class RawMetadata(TypedDict, total=False):
     license_expression: str
     license_files: list[str]
 
+    # Metadata 2.5 - PEP 771
+    default_extra: list[str]
+
 
 _STRING_FIELDS = {
     "author",
@@ -463,8 +466,8 @@ _NOT_FOUND = object()
 
 
 # Keep the two values in sync.
-_VALID_METADATA_VERSIONS = ["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4"]
-_MetadataVersion = Literal["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4"]
+_VALID_METADATA_VERSIONS = ["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4", "2.5"]
+_MetadataVersion = Literal["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4", "2.5"]
 
 _REQUIRED_ATTRS = frozenset(["metadata_version", "name", "version"])
 
@@ -861,3 +864,9 @@ class Metadata:
     """``Provides`` (deprecated)"""
     obsoletes: _Validator[list[str] | None] = _Validator(added="1.1")
     """``Obsoletes`` (deprecated)"""
+    # PEP 771 lets us define a default `extras_require` if none is passed by the
+    # user.
+    default_extra: _Validator[list[utils.NormalizedName] | None] = _Validator(
+        added="2.5",
+    )
+    """:external:ref:`core-metadata-default-extra`"""

--- a/src/pip/_vendor/pkg_resources/__init__.py
+++ b/src/pip/_vendor/pkg_resources/__init__.py
@@ -3070,6 +3070,8 @@ class Distribution:
         dm = self._dep_map
         deps: list[Requirement] = []
         deps.extend(dm.get(None, ()))
+
+        extras = extras or self.default_extras_require
         for ext in extras:
             try:
                 deps.extend(dm[safe_extra(ext)])
@@ -3321,6 +3323,10 @@ class Distribution:
     @property
     def extras(self):
         return [dep for dep in self._dep_map if dep]
+
+    @property
+    def default_extras_require(self):
+        return self._parsed_pkg_info.get_all('Default-Extra') or []
 
 
 class EggInfoDistribution(Distribution):

--- a/src/pip/_vendor/pkg_resources/__init__.py
+++ b/src/pip/_vendor/pkg_resources/__init__.py
@@ -3326,7 +3326,10 @@ class Distribution:
 
     @property
     def default_extras_require(self):
-        return self._parsed_pkg_info.get_all('Default-Extra') or []
+        info = getattr(self, '_parsed_pkg_info', None)
+        if info is None:
+            return []
+        return info.get_all('Default-Extra') or []
 
 
 class EggInfoDistribution(Distribution):

--- a/src/pip/_vendor/resolvelib/resolvers.py
+++ b/src/pip/_vendor/resolvelib/resolvers.py
@@ -1,4 +1,5 @@
 import collections
+import contextlib
 import itertools
 import operator
 
@@ -172,7 +173,11 @@ class Resolution(object):
         )
         if not criterion.candidates:
             raise RequirementsConflicted(criterion)
-        criteria[identifier] = criterion
+        
+        with contextlib.suppress(AttributeError):
+            requirement._extras = requirement._ireq.extras
+
+        criteria[requirement.name] = criterion
 
     def _remove_information_from_criteria(self, criteria, parents):
         """Remove information from parents of criteria.


### PR DESCRIPTION
This fixes the following scenario:

```
pip install package[]
pip install package
```

with this fix here, the second command installs the default extras (before, there was a warning and the default extras didn't get installed)

This is to address the failure in https://github.com/wheelnext/pep_771-Default-Extras/pull/3

<!---
Thank you for your soon to be pull request. Before you submit this, please
double check to make sure that you've added a news file fragment. In pip we
generate our NEWS.rst from multiple news fragment files, and all pull requests
require either a news file fragment or a marker to indicate they don't require
one.

To read more about adding a news file fragment for your PR, please check out
our documentation at: https://pip.pypa.io/en/latest/development/contributing/#news-entries
-->
