### PR TITLE
Rework of PEP 771 implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, pep_771]
     tags:
       # Tags for all potential release numbers till 2030.
       - "2[0-9].[0-3]" # 20.0 -> 29.3

--- a/src/pip/__init__.py
+++ b/src/pip/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__version__ = "26.2.dev0"
+__version__ = "26.2.dev0+pep771"
 
 
 def main(args: list[str] | None = None) -> int:

--- a/src/pip/_internal/metadata/_json.py
+++ b/src/pip/_internal/metadata/_json.py
@@ -31,6 +31,7 @@ METADATA_FIELDS = [
     ("Requires-Python", False),
     ("Requires-External", True),
     ("Project-URL", True),
+    ("Default-Extra", True),
     ("Provides-Extra", True),
     ("Provides-Dist", True),
     ("Obsoletes-Dist", True),

--- a/src/pip/_internal/metadata/base.py
+++ b/src/pip/_internal/metadata/base.py
@@ -438,13 +438,25 @@ class BaseDistribution(Protocol):
         """Dependencies of this distribution.
 
         For modern .dist-info distributions, this is the collection of
-        "Requires-Dist:" entries in distribution metadata.
+        "Requires-Dist:" entries in distribution metadata, evaluated against
+        the given extras. PEP 771 default extras are not consulted here; the
+        caller is responsible for combining them with ``extras`` if desired
+        (see ``Factory._effective_extras``).
         """
         raise NotImplementedError()
 
     def iter_raw_dependencies(self) -> Iterable[str]:
         """Raw Requires-Dist metadata."""
         return self.metadata.get_all("Requires-Dist", [])
+
+    def iter_default_extras(self) -> Iterable[NormalizedName]:
+        """PEP 771 default extras declared by this distribution.
+
+        For modern .dist-info distributions, this is the collection of
+        "Default-Extra:" entries in distribution metadata. The returned
+        names are normalised.
+        """
+        raise NotImplementedError()
 
     def iter_provided_extras(self) -> Iterable[NormalizedName]:
         """Extras provided by this distribution.

--- a/src/pip/_internal/metadata/importlib/_dists.py
+++ b/src/pip/_internal/metadata/importlib/_dists.py
@@ -215,6 +215,12 @@ class Distribution(BaseDistribution):
             return email.message.Message()
         return cast(email.message.Message, metadata)
 
+    def iter_default_extras(self) -> Iterable[NormalizedName]:
+        return [
+            canonicalize_name(extra)
+            for extra in self.metadata.get_all("Default-Extra", [])
+        ]
+
     def iter_provided_extras(self) -> Iterable[NormalizedName]:
         return [
             canonicalize_name(extra)

--- a/src/pip/_internal/metadata/pkg_resources.py
+++ b/src/pip/_internal/metadata/pkg_resources.py
@@ -243,6 +243,9 @@ class Distribution(BaseDistribution):
             extras = [self._extra_mapping[extra] for extra in relevant_extras]
         return self._dist.requires(extras)
 
+    def iter_default_extras(self) -> Iterable[NormalizedName]:
+        return self._dist.default_extras_require or []
+
     def iter_provided_extras(self) -> Iterable[NormalizedName]:
         return self._extra_mapping.keys()
 

--- a/src/pip/_internal/req/constructors.py
+++ b/src/pip/_internal/req/constructors.py
@@ -48,6 +48,12 @@ __all__ = [
     "parse_editable",
 ]
 
+# Matches an empty extras list, optionally with internal whitespace. PEP 771
+# uses ``pkg[]`` to mean "install pkg without applying any default extras";
+# PEP 508's parser silently treats ``pkg[]`` and ``pkg`` the same, so we
+# detect the marker ourselves before delegating to it.
+_EMPTY_EXTRAS_RE = re.compile(r"\[\s*\]")
+
 logger = logging.getLogger(__name__)
 
 # All standard version specifier operators
@@ -55,7 +61,19 @@ logger = logging.getLogger(__name__)
 operators = ("~=", "==", "!=", "<=", ">=", "<", ">", "===")
 
 
-def _strip_extras(path: str) -> tuple[str, str | None]:
+def _strip_empty_extras(req_string: str) -> tuple[str, bool]:
+    """Detect and remove the PEP 771 ``[]`` empty-extras marker.
+
+    Returns the input with the first ``[]`` (allowing internal whitespace)
+    stripped, and a boolean indicating whether the marker was present.
+    """
+    if _EMPTY_EXTRAS_RE.search(req_string) is None:
+        return req_string, False
+    return _EMPTY_EXTRAS_RE.sub("", req_string, count=1), True
+
+
+def _strip_extras(path: str) -> tuple[str, str | None, bool]:
+    path, explicit_no_default_extras = _strip_empty_extras(path)
     m = re.match(r"^(.+)(\[[^\]]+\])$", path)
     extras = None
     if m:
@@ -63,8 +81,7 @@ def _strip_extras(path: str) -> tuple[str, str | None]:
         extras = m.group(2)
     else:
         path_no_extras = path
-
-    return path_no_extras, extras
+    return path_no_extras, extras, explicit_no_default_extras
 
 
 def convert_extras(extras: str | None) -> set[str]:
@@ -99,8 +116,12 @@ def _set_requirement_extras(req: Requirement, new_extras: set[str]) -> Requireme
 
 
 def _parse_direct_url_editable(editable_req: str) -> tuple[str | None, str, set[str]]:
+    # ``packaging.Requirement`` accepts and silently drops the PEP 771 ``[]``
+    # marker; the caller is responsible for detecting it before delegating
+    # here (``_strip_empty_extras``).
+    candidate, _ = _strip_empty_extras(editable_req)
     try:
-        req = Requirement(editable_req)
+        req = Requirement(candidate)
     except InvalidRequirement:
         pass
     else:
@@ -120,7 +141,7 @@ def _parse_pip_syntax_editable(editable_req: str) -> tuple[str | None, str, set[
     url = editable_req
 
     # If a file path is specified with extras, strip off the extras.
-    url_no_extras, extras = _strip_extras(url)
+    url_no_extras, extras, _ = _strip_extras(url)
 
     if os.path.isdir(url_no_extras):
         # Treating it as code that has already been checked out
@@ -238,9 +259,14 @@ class RequirementParts:
     link: Link | None
     markers: Marker | None
     extras: set[str]
+    explicit_no_default_extras: bool = False
 
 
 def parse_req_from_editable(editable_req: str) -> RequirementParts:
+    # PEP 771: ``pkg[]`` opts out of default extras. Detect it on the raw
+    # input here so that ``parse_editable`` (which is part of pip's stable
+    # public surface) can keep returning a 3-tuple.
+    _, explicit_no_default_extras = _strip_empty_extras(editable_req)
     name, url, extras_override = parse_editable(editable_req)
 
     if name is not None:
@@ -253,7 +279,9 @@ def parse_req_from_editable(editable_req: str) -> RequirementParts:
 
     link = Link(url)
 
-    return RequirementParts(req, link, None, extras_override)
+    return RequirementParts(
+        req, link, None, extras_override, explicit_no_default_extras
+    )
 
 
 # ---- The actual constructors follow ----
@@ -286,6 +314,7 @@ def install_req_from_editable(
         hash_options=hash_options,
         config_settings=config_settings,
         extras=parts.extras,
+        explicit_no_default_extras=parts.explicit_no_default_extras,
     )
 
 
@@ -362,10 +391,11 @@ def parse_req_from_line(name: str, line_source: str | None) -> RequirementParts:
     link = None
     extras_as_string = None
 
+    explicit_no_default_extras = False
     if is_url(name):
         link = Link(name)
     else:
-        p, extras_as_string = _strip_extras(path)
+        p, extras_as_string, explicit_no_default_extras = _strip_extras(path)
         url = _get_url_from_path(p, name)
         if url is not None:
             link = Link(url)
@@ -418,7 +448,7 @@ def parse_req_from_line(name: str, line_source: str | None) -> RequirementParts:
     else:
         req = None
 
-    return RequirementParts(req, link, markers, extras)
+    return RequirementParts(req, link, markers, extras, explicit_no_default_extras)
 
 
 def install_req_from_line(
@@ -451,6 +481,7 @@ def install_req_from_line(
         constraint=constraint,
         extras=parts.extras,
         user_supplied=user_supplied,
+        explicit_no_default_extras=parts.explicit_no_default_extras,
     )
 
 
@@ -460,6 +491,7 @@ def install_req_from_req_string(
     isolated: bool = False,
     user_supplied: bool = False,
 ) -> InstallRequirement:
+    req_string, explicit_no_default_extras = _strip_empty_extras(req_string)
     try:
         req = get_requirement(req_string)
     except InvalidRequirement as exc:
@@ -487,6 +519,7 @@ def install_req_from_req_string(
         comes_from,
         isolated=isolated,
         user_supplied=user_supplied,
+        explicit_no_default_extras=explicit_no_default_extras,
     )
 
 
@@ -535,6 +568,7 @@ def install_req_from_link_and_ireq(
         hash_options=ireq.hash_options,
         config_settings=ireq.config_settings,
         user_supplied=ireq.user_supplied,
+        explicit_no_default_extras=ireq.explicit_no_default_extras,
     )
 
 
@@ -559,6 +593,10 @@ def install_req_drop_extras(ireq: InstallRequirement) -> InstallRequirement:
         config_settings=ireq.config_settings,
         user_supplied=ireq.user_supplied,
         permit_editable_wheels=ireq.permit_editable_wheels,
+        # If the original explicitly listed extras then the extras-less clone
+        # represents the bare base requirement; per PEP 771 we must not turn
+        # around and apply default extras to it.
+        explicit_no_default_extras=ireq.explicit_no_default_extras or bool(ireq.extras),
     )
 
 

--- a/src/pip/_internal/req/req_install.py
+++ b/src/pip/_internal/req/req_install.py
@@ -83,6 +83,7 @@ class InstallRequirement:
         permit_editable_wheels: bool = False,
         locked_link: Link | None = None,
         locked_version: Version | None = None,
+        explicit_no_default_extras: bool = False,
     ) -> None:
         assert req is None or isinstance(req, Requirement), req
         self.req = req
@@ -137,6 +138,11 @@ class InstallRequirement:
             self.extras = req.extras
         else:
             self.extras = set()
+        # PEP 771: True when the user wrote ``pkg[]`` (or its dependency-spec
+        # equivalent), explicitly suppressing this distribution's default
+        # extras. Distinct from ``not self.extras`` (which can also mean
+        # "no extras specified, fall back to defaults").
+        self.explicit_no_default_extras = explicit_no_default_extras
         if markers is None and req:
             markers = req.marker
         self.markers = markers

--- a/src/pip/_internal/resolution/resolvelib/candidates.py
+++ b/src/pip/_internal/resolution/resolvelib/candidates.py
@@ -84,6 +84,7 @@ def make_install_req_from_link(
     ireq.original_link = template.original_link
     ireq.link = link
     ireq.extras = template.extras
+    ireq.explicit_no_default_extras = template.explicit_no_default_extras
     return ireq
 
 
@@ -106,6 +107,7 @@ def make_install_req_from_editable(
         config_settings=template.config_settings,
     )
     ireq.extras = template.extras
+    ireq.explicit_no_default_extras = template.explicit_no_default_extras
     return ireq
 
 
@@ -128,6 +130,7 @@ def _make_install_req_from_dist(
         config_settings=template.config_settings,
     )
     ireq.satisfied_by = dist
+    ireq.explicit_no_default_extras = template.explicit_no_default_extras
     return ireq
 
 
@@ -272,9 +275,13 @@ class _InstallRequirementBackedCandidate(Candidate):
         # Emit the Requires-Python requirement first to fail fast on
         # unsupported candidates and avoid pointless downloads/preparation.
         yield self._factory.make_requires_python_requirement(self.dist.requires_python)
-        requires = self.dist.iter_dependencies() if with_requires else ()
-        for r in requires:
-            yield from self._factory.make_requirements_from_spec(str(r), self._ireq)
+        if not with_requires:
+            return
+        extras = self._factory._effective_extras(self._ireq, self.dist)
+        for r in self.dist.iter_dependencies(extras):
+            yield from self._factory.make_requirements_from_spec(
+                str(r), self._ireq, extras
+            )
 
     def get_install_requirement(self) -> InstallRequirement | None:
         return self._ireq
@@ -423,8 +430,11 @@ class AlreadyInstalledCandidate(Candidate):
             return
 
         try:
-            for r in self.dist.iter_dependencies():
-                yield from self._factory.make_requirements_from_spec(str(r), self._ireq)
+            extras = self._factory._effective_extras(self._ireq, self.dist)
+            for r in self.dist.iter_dependencies(extras):
+                yield from self._factory.make_requirements_from_spec(
+                    str(r), self._ireq, extras
+                )
         except InvalidRequirement as exc:
             raise InvalidInstalledPackage(dist=self.dist, invalid_exc=exc) from None
 

--- a/src/pip/_internal/resolution/resolvelib/factory.py
+++ b/src/pip/_internal/resolution/resolvelib/factory.py
@@ -141,6 +141,23 @@ class Factory:
         msg = f"{link.filename} is not a supported wheel on this platform."
         raise UnsupportedWheel(msg)
 
+    @staticmethod
+    def _effective_extras(
+        ireq: InstallRequirement, dist: BaseDistribution
+    ) -> frozenset[str]:
+        """PEP 771: pick the extras to materialise for ``ireq`` against
+        ``dist``.
+
+        - User-specified extras (eg ``pkg[ext]``) win outright.
+        - ``pkg[]`` (``explicit_no_default_extras``) yields no extras.
+        - Otherwise apply the distribution's PEP 771 default extras.
+        """
+        if ireq.extras:
+            return frozenset(ireq.extras)
+        if ireq.explicit_no_default_extras:
+            return frozenset()
+        return frozenset(dist.iter_default_extras())
+
     def _make_extras_candidate(
         self,
         base: BaseCandidate,
@@ -182,7 +199,7 @@ class Factory:
         base: BaseCandidate | None = self._make_base_candidate_from_link(
             link, template, name, version
         )
-        if not extras or base is None:
+        if base is None or not extras:
             return base
         return self._make_extras_candidate(base, extras, comes_from=template)
 
@@ -534,6 +551,9 @@ class Factory:
                 (or link) and one with the extra. This allows centralized constraint
                 handling for the base, resulting in fewer candidate rejections.
         """
+        if isinstance(ireq.comes_from, InstallRequirement):
+            requested_extras = requested_extras or ireq.comes_from.extras
+
         if not ireq.match_markers(requested_extras):
             logger.info(
                 "Ignoring %s: markers '%s' don't match your environment",
@@ -556,6 +576,7 @@ class Factory:
                 name=canonicalize_name(ireq.name) if ireq.name else None,
                 version=None,
             )
+
             if cand is None:
                 # There's no way we can satisfy a URL requirement if the underlying
                 # candidate fails to build. An unnamed URL must be user-supplied, so
@@ -570,7 +591,10 @@ class Factory:
                 # require the base from the link
                 yield self.make_requirement_from_candidate(cand)
                 if ireq.extras:
-                    # require the extras on top of the base candidate
+                    # require the user-specified extras on top of the base
+                    # candidate. PEP 771 default extras are applied later by
+                    # the base candidate's iter_dependencies, so they don't
+                    # need a separate ExtrasCandidate here.
                     yield self.make_requirement_from_candidate(
                         self._make_extras_candidate(cand, frozenset(ireq.extras))
                     )

--- a/src/pip/_internal/resolution/resolvelib/requirements.py
+++ b/src/pip/_internal/resolution/resolvelib/requirements.py
@@ -129,10 +129,13 @@ class SpecifierWithoutExtrasRequirement(SpecifierRequirement):
 
     def __init__(self, ireq: InstallRequirement) -> None:
         assert ireq.link is None, "This is a link, not a specifier"
+        # install_req_drop_extras already sets ``explicit_no_default_extras``
+        # when the original ireq had extras, so the bare base requirement does
+        # not turn around and pull in PEP 771 defaults.
         self._ireq = install_req_drop_extras(ireq)
         self._equal_cache: str | None = None
         self._hash: int | None = None
-        self._extras = frozenset(canonicalize_name(e) for e in self._ireq.extras)
+        self._extras = frozenset()
 
     @property
     def _equal(self) -> str:

--- a/src/pip/_vendor/packaging/metadata.py
+++ b/src/pip/_vendor/packaging/metadata.py
@@ -131,6 +131,9 @@ class RawMetadata(TypedDict, total=False):
     import_names: list[str]
     import_namespaces: list[str]
 
+    # Metadata 2.6 - PEP 771
+    default_extra: list[str]
+
 
 # 'keywords' is special as it's a string in the core metadata spec, but we
 # represent it as a list.
@@ -168,6 +171,7 @@ _LIST_FIELDS = {
     "supported_platforms",
     "import_names",
     "import_namespaces",
+    "default_extra",
 }
 
 _DICT_FIELDS = {
@@ -254,6 +258,7 @@ _EMAIL_TO_RAW_MAPPING = {
     "author": "author",
     "author-email": "author_email",
     "classifier": "classifiers",
+    "default-extra": "default_extra",
     "description": "description",
     "description-content-type": "description_content_type",
     "download-url": "download_url",
@@ -511,8 +516,8 @@ _NOT_FOUND = object()
 
 
 # Keep the two values in sync.
-_VALID_METADATA_VERSIONS = ["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4", "2.5"]
-_MetadataVersion = Literal["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4", "2.5"]
+_VALID_METADATA_VERSIONS = ["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6"]
+_MetadataVersion = Literal["1.0", "1.1", "1.2", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6"]
 
 _REQUIRED_ATTRS = frozenset(["metadata_version", "name", "version"])
 
@@ -928,6 +933,12 @@ class Metadata:
     """``Provides`` (deprecated)"""
     obsoletes: _Validator[list[str] | None] = _Validator(added="1.1")
     """``Obsoletes`` (deprecated)"""
+    # PEP 771 lets us define a default `extras_require` if none is passed by the
+    # user.
+    default_extra: _Validator[list[utils.NormalizedName] | None] = _Validator(
+        added="2.6",
+    )
+    """:external:ref:`core-metadata-default-extra`"""
 
     def as_rfc822(self) -> RFC822Message:
         """

--- a/src/pip/_vendor/pkg_resources/__init__.py
+++ b/src/pip/_vendor/pkg_resources/__init__.py
@@ -3322,6 +3322,13 @@ class Distribution:
     def extras(self):
         return [dep for dep in self._dep_map if dep]
 
+    @property
+    def default_extras_require(self):
+        # PEP 771 default extras are only expressible in modern dist-info
+        # metadata; legacy egg-info distributions can't carry them, so the
+        # base class returns an empty list and DistInfoDistribution overrides.
+        return []
+
 
 class EggInfoDistribution(Distribution):
     def _reload_version(self):
@@ -3360,6 +3367,10 @@ class DistInfoDistribution(Distribution):
             metadata = self.get_metadata(self.PKG_INFO)
             self._pkg_info = email.parser.Parser().parsestr(metadata)
             return self._pkg_info
+
+    @property
+    def default_extras_require(self):
+        return self._parsed_pkg_info.get_all('Default-Extra') or []
 
     @property
     def _dep_map(self):


### PR DESCRIPTION
I worked on getting the CI suite running again by rebasing our PEP 771 changes onto main, and discovered that a number of bugs had been introduced, partially due to the use of the hacky sentinel extra. I was curious to see if we could re-write the PEP 771 implementation to avoid the  sentinel extra and just generally make the implementation more robust.

This is a PR into the ``pep771-rework``  branch which is currently up-to-date with ``upstream/main``, so we should be able to get the CI running and hopefully passing. If we agree on this implementation, we could merge this in and then reset the ``pep771`` branch to be the same as ``pep771-rework``. I'm doing it this way rather than just opening it as changes to the ``pep771`` branch since the latter is very out of date with ``upstream/main`` so the CI isn't running.
